### PR TITLE
Add GitHub Actions CI for Python 3.9–3.14 matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  push:
+    branches: ["master", "main"]
+  pull_request:
+    branches: ["master", "main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
+      - name: Install dependencies
+        run: pip install -e . responses pytest
+
+      - name: Run tests
+        run: pytest tests/tests.py -v


### PR DESCRIPTION
## Summary

- Add `.github/workflows/tests.yml` — runs mocked pytest suite on Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
- `allow-prereleases: true` enables Python 3.14 (currently in pre-release)
- `fail-fast: false` ensures all versions are tested even if one fails

## Test plan

- [x] Verified locally: all 6 tests pass on Python 3.9–3.14